### PR TITLE
Add date type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The `type of value` should be equal to the expected value
 { type: 'boolean' }
 { type: 'object' }
 { type: 'null' }
+{ type: 'date' }
 { type: 'any' }
 { type: ['boolean', 'string'] }
 ```

--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -305,6 +305,10 @@
           value = false;
         }
       }
+
+      if ('date' === schema.type) {
+        value = new Date(value);
+      }
       //modify source object if we have an option and values are differ
       //for simple value
       if (options.castSource && indexInArray == null && object[property] !== value) {
@@ -469,7 +473,8 @@
           type === 'number' ? typeof val === 'number' :
           type === 'integer' ? typeof val === 'number' && Math.floor(val) === val :
           type === 'null' ? val === null :
-          type === 'boolean'? typeof val === 'boolean' :
+          type === 'boolean' ? typeof val === 'boolean' :
+          type === 'date' ? isDate(val) :
           type === 'any' ? typeof val !== 'undefined' : false) {
         return callback(null, type);
       }
@@ -548,6 +553,11 @@
 
   function isString(value) {
     return Object.prototype.toString.call(value) == '[object String]';
+  }
+
+  function isDate(value) {
+    return Object.prototype.toString.call(value) == '[object Date]' &&
+      value && value.getTime && isFunction(value.getTime) && !isNaN(value.getTime());
   }
 
   function ValidatorError(message) {


### PR DESCRIPTION
Add support of type `date` for instances of JavaScript `Date`.

Now it's possible to use type `date` in schema, for example:

```javascript
conform(
	{date: new Date()},
	{type: 'date'}
);
```

For type `date` also works `cast` and `castSource` options:

```javascript
var doc = {date: '2017-04-06'};

conform(
	doc,
	{type: 'date'},
	{cast: true, castSource: true}
);

console.log(doc);
// Thu Apr 06 2017 03:00:00 GMT+0300 (MSK)
```

And some tests for type and cast options are added.